### PR TITLE
ideas for next gen commands

### DIFF
--- a/src/main/java/frc/robot/ng/RobotContainer.java
+++ b/src/main/java/frc/robot/ng/RobotContainer.java
@@ -1,0 +1,205 @@
+// Copyright (c) 2024 - 2025 : FRC 3102 : Tech-No-Tigers
+// https://www.tnt3102.org
+
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file at
+// the root directory of this project.
+
+package frc.robot.ng;
+
+import static edu.wpi.first.units.Units.*;
+
+import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import com.pathplanner.lib.auto.AutoBuilder;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.XboxController.*;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
+import edu.wpi.first.wpilibj2.command.button.CommandGenericHID;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
+import frc.robot.Telemetry;
+import frc.robot.Autos.Drive1;
+import frc.robot.ng.commands.*;
+import frc.robot.generated.TunerConstants;
+import frc.robot.subsystems.CommandSwerveDrivetrain;
+import frc.robot.subsystems.Elevator;
+import frc.robot.ng.subsystems.*;
+
+public class RobotContainer {
+
+	Elevator m_elevator = new Elevator();
+	FishHook m_fish_hook = new FishHook();
+
+	private double MaxSpeed = TunerConstants.kSpeedAt12Volts.in(MetersPerSecond); // kSpeedAt12Volts desired top speed
+	private double MaxAngularRate = RotationsPerSecond.of(0.75)
+			.in(RadiansPerSecond); // 3/4 of a rotation per second max angular velocity
+
+	/* Setting up bindings for necessary control of the swerve drive platform */
+	private final SwerveRequest.FieldCentric drive = new SwerveRequest.FieldCentric()
+			.withDeadband(MaxSpeed * 0.05)
+			.withRotationalDeadband(MaxAngularRate * 0.05) // Add a 10% deadband
+			.withDriveRequestType(
+					DriveRequestType.OpenLoopVoltage); // Use open-loop control for drive motors
+	private final SwerveRequest.SwerveDriveBrake brake = new SwerveRequest.SwerveDriveBrake();
+	private final SwerveRequest.PointWheelsAt point = new SwerveRequest.PointWheelsAt();
+	private final SwerveRequest.RobotCentric forwardStraight = new SwerveRequest.RobotCentric()
+			.withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+
+	private final Telemetry logger = new Telemetry(MaxSpeed);
+
+	private final CommandXboxController driverController = new CommandXboxController(0);
+	private final CommandGenericHID coDriverController = new CommandGenericHID(1);
+	private final Joystick codriverJoystick = new Joystick(1);
+
+	public final CommandSwerveDrivetrain drivetrain = TunerConstants.createDrivetrain();
+
+	/* Path follower */
+	private final SendableChooser<Command> autoChooser;
+
+	public RobotContainer() {
+		autoChooser = AutoBuilder.buildAutoChooser("Tests");
+		SmartDashboard.putData("Auto Mode", autoChooser);
+
+		autoChooser.setDefaultOption("Do Nothing", new PrintCommand("Do Nothing"));
+		autoChooser.addOption("Drive", new Drive1(drivetrain));
+		autoChooser.addOption("forward", drivetrain.getAutoPath("Drive"));
+
+		configureBindings();
+
+		// Configure the pathplanner named commands
+		// CommandRegristry.setupNamedCommands(m_elevator, m_fish_hook);
+	}
+
+	private void configureBindings() {
+		// Note that X is defined as forward according to WPILib convention,
+		// and Y is defined as to the left according to WPILib convention.
+		drivetrain.setDefaultCommand(
+				// Drivetrain will execute this command periodically
+				drivetrain.applyRequest(
+						() -> drive
+								.withVelocityX(
+										-driverController.getLeftY()
+												* MaxSpeed) // Drive forward with negative Y (forward)
+								.withVelocityY(
+										-driverController.getLeftX()
+												* MaxSpeed) // Drive left with negative X (left)
+								.withRotationalRate(
+										-driverController.getRightX()
+												* MaxAngularRate) // Drive counterclockwise with negative X (left)
+				));
+
+		// TODO Find button for:
+		// driverController.a().toggleOnTrue(drivetrain.applyRequest(() ->
+		// brake));
+		// joystick.b().whileTrue(drivetrain.applyRequest(() ->
+		// point.withModuleDirection(new Rotation2d(-joystick.getLeftY(),
+		// -joystick.getLeftX()))
+		// ));
+
+		driverController
+				.pov(0)
+				.whileTrue(
+						drivetrain.applyRequest(() -> forwardStraight.withVelocityX(0.5).withVelocityY(0)));
+		driverController
+				.pov(180)
+				.whileTrue(
+						drivetrain.applyRequest(() -> forwardStraight.withVelocityX(-0.5).withVelocityY(0)));
+
+		// Run SysId routines when holding back/start and X/Y.
+		// Note that each routine should be run exactly once in a single log.
+		driverController
+				.back()
+				.and(driverController.y())
+				.whileTrue(drivetrain.sysIdDynamic(Direction.kForward));
+		driverController
+				.back()
+				.and(driverController.x())
+				.whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
+		driverController
+				.start()
+				.and(driverController.y())
+				.whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
+		driverController
+				.start()
+				.and(driverController.x())
+				.whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
+
+		// reset the field-centric heading on left bumper press
+		driverController.button(8).onTrue(drivetrain.runOnce(() -> drivetrain.seedFieldCentric()));
+
+		drivetrain.registerTelemetry(logger::telemeterize);
+
+		// Driver Buttons
+
+		// Coral Scoring
+		// driverController
+		// .a()
+		// .onTrue(new CMD_ScoringState(ScoringState.State.L1, m_elevator,
+		// m_fish_hook));
+		// driverController
+		// .b()
+		// .onTrue(new CMD_ScoringState(ScoringState.State.L2, m_elevator,
+		// m_fish_hook));
+		// driverController
+		// .x()
+		// .onTrue(new CMD_ScoringState(ScoringState.State.L3, m_elevator,
+		// m_fish_hook));
+		// driverController
+		// .y()
+		// .onTrue(new CMD_ScoringState(ScoringState.State.L4, m_elevator,
+		// m_fish_hook));
+
+		// TODO right bumper for right side of reef alignment
+
+		// TODO left bumper for left side of reef alignment
+
+		// Idle to bottom
+		// driverController
+		// .button(7)
+		// .onTrue(new CMD_ScoringState(ScoringState.State.BOTTOM, m_elevator,
+		// m_fish_hook));
+
+		// driverController.rightBumper().whileTrue(new ElevatorUp(m_elevator));
+
+		// driverController.leftBumper().whileTrue(new ElevatorDown(m_elevator));
+		// Co-Driver Buttons
+
+		coDriverController
+				.button(1) // trigger
+				.whileTrue(new CoralManual(m_fish_hook));
+
+		coDriverController
+				.button(2) // Bottom Face Button
+				.onTrue(new CoralAuto(m_fish_hook));
+
+		coDriverController
+				.button(3) // left face buttom
+				.whileTrue(new AlgaeIn(m_fish_hook));
+
+		coDriverController
+				.button(4) // right face button
+				.whileTrue(new AlgaeOut(m_fish_hook));
+
+		// m_fish_hook.run(new tilt(() -> coDriverController.getY().m_Fishhook));
+
+		m_fish_hook.setDefaultCommand(
+
+				new FishHookAngle(
+						m_fish_hook, () -> codriverJoystick.getRawAxis(Joystick.AxisType.kY.value) * 0.1));
+
+		/*
+		 * TODO
+		 * climber
+		 */
+	}
+
+	public Command getAutonomousCommand() {
+		/* Run the path selected from the auto chooser */
+		return autoChooser.getSelected();
+	}
+}

--- a/src/main/java/frc/robot/ng/commands/AlgaeIn.java
+++ b/src/main/java/frc/robot/ng/commands/AlgaeIn.java
@@ -1,0 +1,25 @@
+package frc.robot.ng.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.ng.subsystems.FishHook;
+
+public class AlgaeIn extends Command {
+
+    private final FishHook fishHook;
+
+    public AlgaeIn(FishHook fishHook) {
+        this.fishHook = fishHook;
+        this.addRequirements(fishHook);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        fishHook.algaeIdle();
+    }
+
+    @Override
+    public void initialize() {
+        fishHook.algaeRollIn();
+    }
+
+}

--- a/src/main/java/frc/robot/ng/commands/AlgaeOut.java
+++ b/src/main/java/frc/robot/ng/commands/AlgaeOut.java
@@ -1,0 +1,25 @@
+package frc.robot.ng.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.ng.subsystems.FishHook;
+
+public class AlgaeOut extends Command {
+
+    private final FishHook fishHook;
+
+    public AlgaeOut(FishHook fishHook) {
+        this.fishHook = fishHook;
+        this.addRequirements(fishHook);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        fishHook.algaeIdle();
+    }
+
+    @Override
+    public void initialize() {
+        fishHook.algaeRollOut();
+    }
+
+}

--- a/src/main/java/frc/robot/ng/commands/CoralAuto.java
+++ b/src/main/java/frc/robot/ng/commands/CoralAuto.java
@@ -1,0 +1,19 @@
+package frc.robot.ng.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.ng.subsystems.FishHook;
+
+public class CoralAuto extends Command {
+
+    private final FishHook fishHook;
+
+    public CoralAuto(FishHook fishhook) {
+        fishHook = fishhook;
+        addRequirements(fishHook);
+    }
+
+    @Override
+    public void initialize() {
+        fishHook.intakeAuto();
+    }
+}

--- a/src/main/java/frc/robot/ng/commands/CoralManual.java
+++ b/src/main/java/frc/robot/ng/commands/CoralManual.java
@@ -1,0 +1,24 @@
+package frc.robot.ng.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.ng.subsystems.FishHook;
+
+public class CoralManual extends Command {
+
+    private final FishHook fishHook;
+
+    public CoralManual(FishHook fishhook) {
+        fishHook = fishhook;
+        addRequirements(fishHook);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        fishHook.intakeIdle();
+    }
+
+    @Override
+    public void initialize() {
+        fishHook.intakeManual();
+    }
+}

--- a/src/main/java/frc/robot/ng/state/AlgaeState.java
+++ b/src/main/java/frc/robot/ng/state/AlgaeState.java
@@ -1,0 +1,17 @@
+package frc.robot.ng.state;
+
+public enum AlgaeState {
+    Idle(0),
+    RollIn(0.2),
+    RollOut(-0.2);
+
+    private AlgaeState(double speed) {
+        this.speed = speed;
+    }
+
+    private double speed;
+
+    public double getSpeed() {
+        return this.speed;
+    }
+}

--- a/src/main/java/frc/robot/ng/state/CoralState.java
+++ b/src/main/java/frc/robot/ng/state/CoralState.java
@@ -1,0 +1,17 @@
+package frc.robot.ng.state;
+
+public enum IntakeState {
+    Idle(0),
+    Manual(0.5),
+    Auto(0.2);
+
+    private IntakeState(double speed) {
+        this.speed = speed;
+    }
+
+    private double speed;
+
+    public double getSpeed() {
+        return this.speed;
+    }
+}

--- a/src/main/java/frc/robot/ng/subsystems/FishHook.java
+++ b/src/main/java/frc/robot/ng/subsystems/FishHook.java
@@ -1,0 +1,117 @@
+// Copyright (c) 2024 - 2025 : FRC 3102 : Tech-No-Tigers
+// https://www.tnt3102.org
+
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file at
+// the root directory of this project.
+
+package frc.robot.ng.subsystems;
+
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.ng.state.AlgaeState;
+import frc.robot.ng.state.CoralState;
+
+public class Fish_Hook extends SubsystemBase {
+
+	private final TalonFX m_coral = new TalonFX(10);
+	private final TalonFX m_algae = new TalonFX(9);
+	private final TalonFX m_tilt = new TalonFX(8);
+	private AlgaeState algaeState = AlgaeState.Idle;
+	private CoralState coralState = CoralState.Idle;
+
+	public Fish_Hook() {
+
+		var talonFXconfigs = new TalonFXConfiguration();
+
+		// in init function, set slot 0 gains
+		var slot0Configs = talonFXconfigs.Slot0;
+		slot0Configs.kS = 0.2; // voltage needed to overcome static friction
+		slot0Configs.kV = 0.1; // output per unit of target velocity (output/rps)
+		slot0Configs.kA = 0.1; // output per unit of target acceleration (output/rps^2)
+		slot0Configs.kP = 2.4; // output per unit of error in position (output/rotation), An error of 1
+								// rotation
+		// results in 2.4 V output
+		slot0Configs.kI = 0; // output per unit of integrated error in position (output/(rotation*s)), no
+								// output for
+		// integrated error
+		slot0Configs.kD = 0.1; // output per unit of error in velocity (output/rps), A velocity of 1 rps
+								// results in
+		// 0.1 V output
+
+		var motionMagicConfigs = talonFXconfigs.MotionMagic;
+		motionMagicConfigs.MotionMagicCruiseVelocity = 1000; // velocity in units/100ms
+		motionMagicConfigs.MotionMagicAcceleration = 1000; // acceleration in units/100ms^2
+		motionMagicConfigs.MotionMagicJerk = 1000; // jerk in units/100ms^3
+
+		m_tilt.getConfigurator().apply(talonFXconfigs);
+
+		m_coral.getConfigurator().apply(new TalonFXConfiguration());
+		m_coral.setNeutralMode(NeutralModeValue.Brake);
+
+		m_algae.getConfigurator().apply(new TalonFXConfiguration());
+		m_algae.setNeutralMode(NeutralModeValue.Brake);
+
+		m_tilt.getConfigurator().apply(new TalonFXConfiguration());
+		m_tilt.setNeutralMode(NeutralModeValue.Brake);
+	}
+
+	final PositionVoltage drive1PositionVoltage = new PositionVoltage(0).withSlot(0);
+
+	@Override
+	public void periodic() {
+	}
+
+	@Override
+	public void simulationPeriodic() {
+	}
+
+	private void updateCoralState(CoralState newState) {
+		if (!newState.equals(coralState)) {
+			coralState = newState;
+			m_coral.set(coralState.getSpeed());
+		}
+	}
+
+	public void intakeIdle() {
+		updateCoralState(CoralState.Idle);
+	}
+
+	public void intakeManual() {
+		updateCoralState(CoralState.Manual);
+	}
+
+	public void intakeAuto() {
+		updateCoralState(CoralState.Auto);
+	}
+
+	private void updateAlgaeState(AlgaeState newState) {
+		if (!newState.equals(algaeState)) {
+			algaeState = newState;
+			m_algae.set(algaeState.getSpeed());
+		}
+	}
+
+	public void algaeIdle() {
+		updateAlgaeState(AlgaeState.Idle);
+	}
+
+	public void algaeRollOut() {
+		updateAlgaeState(AlgaeState.RollOut);
+	}
+
+	public void algaeRollIn() {
+		updateAlgaeState(AlgaeState.RollIn);
+	}
+
+	public void setPosition(double position) {
+		m_tilt.setControl(new PositionVoltage(position).withSlot(0));
+	}
+
+	public void tilt(Double speed) {
+		m_tilt.set(speed);
+	}
+}


### PR DESCRIPTION
I think we should ignore the stuff in the `state/` directory, its basically just adding an extra layer on top that doesn't buy us anything.

The main ideas are:
* split subsystems out into things we actually want to treat as mutually exclusive groups:
    `Fish_Hook` is too big because if we want to tilt the fish hook and run either the intake motors or the algae motors, that's fine and should be allowed to happen.  Currently, they will preempt each other because they're all part of the same Subsystem and the command scheduler will interrupt other commands that are already running with the same subsystems, causing undue competition amongst the resources
* Set motor inputs in `initialize()` in commands, not `execute()`.  `execute` is every tick, `initialize` is once per schedule.
* Use `end()` appropriately, such as for setting a motor back to zero when the trigger is released.
* Avoid `Subsystem.run()` in favor of `Subsystem.runOnce()` if you're doing something that shouldn't run every tick.
* Keep `setDefaultCommand` usage to a minimum, mostly just for watching joystick axes.  We also need to be aware of which subsystems these are a part of, because they won't be run if another Command on the same subsystem is running.